### PR TITLE
关于在mount阶段事件注册的优化

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -6,8 +6,6 @@ import {
   isVnode,
   checkVnode,
   setStyleProp,
-  addEvent,
-  removeEvent,
   setAttribute,
   removeAttribute,
   createNode,
@@ -15,6 +13,8 @@ import {
   getSequence,
   vnodeType,
   notTagComponent,
+  addEventListener,
+  removeEventListener
 } from './utils';
 
 // version
@@ -66,7 +66,7 @@ function mount(
     vnode.el = el;
     // props
     if (!isUndef(props)) {
-      addEvent(el, props);
+
       const keys = Object.keys(props);
 
       for (let index = 0; index < keys.length; index++) {
@@ -74,6 +74,10 @@ function mount(
         const propValue = props[key];
         const propValueType = getType(propValue);
 
+        if (key.startsWith("on")) {
+          addEventListener(el, key , propValue);
+        }
+        
         if (propValueType !== 'function' && key !== 'key' && !flag.includes(key)) {
           setAttribute(el, key, propValue);
         }
@@ -162,8 +166,8 @@ function patch(oNode: vnodeType, nNode: vnodeType) {
             }
 
             if (newPropValueType === 'function' && newValue.toString() !== oldValue.toString()) {
-              removeEvent(el, key, oldProps);
-              addEvent(el, newProps);
+              removeEventListener(el , key , oldValue);
+              addEventListener(el , key , newValue)
             }
           } else {
             removeAttribute(el, key);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,12 @@ const SVG_TAGS =
   'linearGradient,stop,radialGradient,' +
   'animateTransform,animateMotion';
 
+const EVENT_TAGS = 
+ 'click,dbclick,mousedown,mouseup,mousemove,mouseover,mouseout,contextmenu'+
+ 'keydown,keyup,keypress,submit,reset,change,focus,blur,input,load,unload,resize,scroll' +
+ 'blur,dragstart,drag,dragenter,dragleave,dragover,drop,dragend,touchstart,touchmove,touchend,touchcancel' +
+ 'animationstart,animationend,animationiteration,transitionend'
+
 function makeMap(str: string): (val: string) => boolean {
   const map: { [key: string]: boolean } = Object.create(null);
   const list = str.split(',');
@@ -34,6 +40,8 @@ function makeMap(str: string): (val: string) => boolean {
 const isHTMLTag = /*#__PURE__*/ makeMap(HTML_TAGS);
 
 const isSVG = /*#__PURE__*/ makeMap(SVG_TAGS);
+
+const isEvent = /*#__PURE__*/ makeMap(EVENT_TAGS);
 
 function isXlink(name: string): boolean {
   return name.charAt(5) === ':' && name.slice(0, 5) === 'xlink';
@@ -148,6 +156,21 @@ function removeEvent(el: HTMLElement, key: string, oldProps: { [key: string]: an
   }
 }
 
+function addEventListener(el:HTMLElement , name:string , listener:EventListenerOrEventListenerObject){
+  const eventName = name.slice(2).toLowerCase();
+  if(isEvent(eventName) && typeof listener === 'function'){
+    el.addEventListener(eventName,listener);
+  }
+}
+
+function removeEventListener(el:HTMLElement , name:string , listener:EventListenerOrEventListenerObject){
+  const eventName = name.slice(2).toLowerCase();
+  if(isEvent(eventName) && typeof listener === 'function'){
+    el.removeEventListener(eventName,listener);
+  }
+  
+}
+
 function setAttribute(el: HTMLElement, key: string, value: string | boolean): void {
   if (typeof isXlink === 'function' && !isXlink(key)) {
     el.setAttribute(key, value.toString());
@@ -244,4 +267,6 @@ export {
   warn,
   getSequence,
   notTagComponent,
+  addEventListener,
+  removeEventListener
 };


### PR DESCRIPTION
优化1：mount阶段减少不必要的遍历

原因：在源码的mount阶段，有一个`addEvent`的函数，它的作用是遍历所有的porps属性，然后找出其中的事件进行注册。
```ts
addEvent(el, props); // 这是一次对props的遍历
const keys = Object.keys(props); 
for (let index = 0; index < keys.length; index++) { // 这也是一次遍历
   ... 
}
```
完全可以把事件注册的函数放在循环里面，用一次遍历搞定，虽然一个节点的属性比较少，这种优化可能无关紧要，但是对于页面成千上万个节点来说，可能就有必要考虑了！


优化二：patch过程中，特定情况下防止重复注册事件。

原因：源码中，在path阶段会有可能进入到这个分支，比如在某次更新过程中函数实现发生变化的情况下。

```ts
if (newPropValueType === 'function' && newValue.toString() !== oldValue.toString()) {
  removeEvent(el, key, oldProps);
  addEvent(el, newProps);
}
```
考虑这种情况 `<h1 onClick={()=>null}  onDbClick={()=>null}>hello<h1>`
如果在一次更新中 onClick 和 onDbClick的实现都发生了变化，进入这个分支后，就会重复注册函数。所以我建议可以将将addEvent换成addEventListener。

该PR作者可以考虑下，最后感谢作者能够开源strve，在你的代码中学习到了很多东西 ！💐💐

